### PR TITLE
Increase MESSAGE_SIZE to accommodate PQC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ description = "usb-device driver for CTAPHID"
 categories = ["embedded", "no-std"]
 
 [dependencies]
-ctap-types = "0.1.0"
 ctaphid-dispatch = "0.1.0"
 embedded-time = "0.12"
 delog = "0.1.0"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,6 +2,4 @@ pub const INTERRUPT_POLL_MILLISECONDS: u8 = 5;
 
 pub const PACKET_SIZE: usize = 64;
 
-// 1200
-// pub const MESSAGE_SIZE: usize = ctap_types::sizes::REALISTIC_MAX_MESSAGE_SIZE;
 pub const MESSAGE_SIZE: usize = 3072;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,4 +2,4 @@ pub const INTERRUPT_POLL_MILLISECONDS: u8 = 5;
 
 pub const PACKET_SIZE: usize = 64;
 
-pub const MESSAGE_SIZE: usize = 3072;
+pub const MESSAGE_SIZE: usize = 20000;

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -234,17 +234,13 @@ impl<'alloc, 'pipe, 'interrupt, Bus: UsbBus> Pipe<'alloc, 'pipe, 'interrupt, Bus
     }
 
     fn cancel_ongoing_activity(&mut self) {
-        // Remove response if it's there
-        if let Some(_response) = self.interchange.take_response() {
-        } else {
+        if matches!(self.state, State::WaitingOnAuthenticator(_)) {
             info_now!("Interrupting request");
             if let Some(Some(i)) = self.interrupt.map(|i| i.load(Ordering::Relaxed)) {
                 info_now!("Loaded some interrupter");
                 i.interrupt();
             }
         }
-
-        self.state = State::Idle;
     }
 
     /// This method handles CTAP packets (64 bytes), until it has assembled


### PR DESCRIPTION
Based on commit dcff9009c3cd1ef9e5b09f8f307aca998fc9a8c8, which is the pinned commit in the `nitrokey-3-firmware` repo.

The size was arrived at by trial and error and should be replaced by a proper calculation in the future.